### PR TITLE
More docs (using httpie) + get rid of redundant code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Akka HTTP microservice example
 
-This project is intended to demonstrate how to use akka-http and Scala to write a simple REST (micro)service. Typical tasks accomplished in this project includes:
+This project demonstrates the [Akka HTTP](http://doc.akka.io/docs/akka-stream-and-http-experimental/current/scala.html) library and Scala to write a simple REST (micro)service. The project shows the following tasks that are typical for most Akka HTTP-based projects:
 
 * starting standalone HTTP server,
-* handling simple, file-based configuration,
+* handling file-based configuration,
 * logging,
 * routing,
 * deconstructing requests,
@@ -13,62 +13,66 @@ This project is intended to demonstrate how to use akka-http and Scala to write 
 * issuing requests to external services,
 * testing with mocking of external services.
 
-Service provides two endpoints - one which gives GeoIP info for given IP and another for calculating geographical distance between given pair of IPs. Project uses great service named [Telize](http://www.telize.com/) which offers JSON IP and GeoIP REST API for free.
+The service in the template provides two REST endpoints - one which gives GeoIP info for given IP and another for calculating geographical distance between given pair of IPs. The project uses the service [Telize](http://www.telize.com/) which offers JSON IP and GeoIP REST API for free.
 
 ## Usage
 
-Start services with sbt:
+Start services using `~ reStart` command:
 
-```
-$ sbt
-> ~re-start
-```
+    $ ./activator
+    [akka-http-microservice]> ~ reStart
 
-then you can start making requests:
+With the service up, you can start sending HTTP requests:
 
-```
-$ curl http://localhost:9000/ip/8.8.8.8
-{
-  "city": "Mountain View",
-  "ip": "8.8.8.8",
-  "latitude": 37.386,
-  "country": "United States",
-  "longitude": -122.0838
-}
-```
+    $ http http://localhost:9000/ip/8.8.8.8
+    HTTP/1.1 200 OK
+    Content-Length: 126
+    Content-Type: application/json; charset=UTF-8
+    Date: Sun, 01 Feb 2015 09:28:08 GMT
+    Server: akka-http/2.3.9
+    
+    {
+        "city": "Mountain View",
+        "country": "United States",
+        "ip": "8.8.8.8",
+        "latitude": 37.386,
+        "longitude": -122.0838
+    }
 
-```
-$ curl -X POST -H 'Content-Type: application/json' http://localhost:9000/ip -d '{"ip1": "8.8.8.8", "ip2": "8.8.4.4"}'
-{
-  "distance": 2201.448386715217,
-  "ip1Info": {
-    "city": "Mountain View",
-    "ip": "8.8.8.8",
-    "latitude": 37.386,
-    "country": "United States",
-    "longitude": -122.0838
-  },
-  "ip2Info": {
-    "ip": "8.8.4.4",
-    "country": "United States",
-    "latitude": 38.0,
-    "longitude": -97.0
-  }
-}
-```
+    $ http http://localhost:9000/ip ip1=8.8.8.8 ip2=8.8.4.4
+    HTTP/1.1 200 OK
+    Content-Length: 306
+    Content-Type: application/json; charset=UTF-8
+    Date: Sun, 01 Feb 2015 09:29:55 GMT
+    Server: akka-http/2.3.9
+    
+    {
+        "distance": 2201.448386715217,
+        "ip1Info": {
+            "city": "Mountain View",
+            "country": "United States",
+            "ip": "8.8.8.8",
+            "latitude": 37.386,
+            "longitude": -122.0838
+        },
+        "ip2Info": {
+            "country": "United States",
+            "ip": "8.8.4.4",
+            "latitude": 38.0,
+            "longitude": -97.0
+        }
+    }
 
 ### Testing
 
-Run tests with sbt:
+Execute tests using `test` command:
 
-```
-$ sbt
-> test
-```
+    $ ./activator
+    > test
 
 ## Author & license
 
-If you have any questions regarding this project contact with:
+If you have any questions regarding this project contact:
 
 Łukasz Sowa <lukasz@theiterators.com> from [Iterators](http://www.theiterators.com).
 


### PR DESCRIPTION
Please review and merge.

I think it's time to forget about `curl` when `httpie` is around (and makes sending requests so much pleasant again).

When a user uses the activator template, it will get `activator` command, too, and that's what I think we should be using instead of `sbt` (a separate installation is needed then while `activator` is required in the first place)

I'm still concerned with how the errors are handled in the code as they require `Accept:text/plain,application/json` while sending requests using `httpie`. I'm gonna file an issue for this.